### PR TITLE
Add mavlink-router dependencies and useful packages to APTGET_EXTRA_PACKAGES

### DIFF
--- a/meta-hovergames-distro/recipes-hovergames/images/imx-image-hovergames-ubuntu.bb
+++ b/meta-hovergames-distro/recipes-hovergames/images/imx-image-hovergames-ubuntu.bb
@@ -309,6 +309,7 @@ APTGET_EXTRA_PACKAGES += "\
 	net-tools \
 	connman \
 	openssh-server \
+	python3-future libtool autoconf pkg-config \
 "
 APTGET_EXTRA_SOURCE_PACKAGES += "\
 	iproute2 \

--- a/meta-hovergames-distro/recipes-hovergames/images/imx-image-hovergames-ubuntu.bb
+++ b/meta-hovergames-distro/recipes-hovergames/images/imx-image-hovergames-ubuntu.bb
@@ -307,6 +307,8 @@ APTGET_EXTRA_PACKAGES += "\
 	apt git vim \
 	ethtool wget ftp iputils-ping lrzsz \
 	net-tools \
+	connman \
+	openssh-server \
 "
 APTGET_EXTRA_SOURCE_PACKAGES += "\
 	iproute2 \


### PR DESCRIPTION
connman, openssh-server: Adding these packages by default will allow users to connect to WiFi using connmanctl as well as connect to the NavQ over ssh.

python3-future, lib tool, autoconf, pkg-config: Dependencies for mavlink-router