### PR TITLE
Fixed gdk-pixbuf compilation error

### DIFF
--- a/meta-hovergames-distro/recipes-gnome/gdk-pixbuf/gdk-pixbuf_2.38.2.bbappend
+++ b/meta-hovergames-distro/recipes-gnome/gdk-pixbuf/gdk-pixbuf_2.38.2.bbappend
@@ -1,18 +1,11 @@
 #
-# This class will generate the proper postinst/postrm scriptlets for pixbuf
-# packages.
+# Override postint with an empty function to fix postinst problems
 #
-
 
 pixbufcache_common() {
 }
 
+
 python populate_packages_append() {
 }
 
-gdkpixbuf_complete() {
-}
-
-
-pixbufcache_sstate_postinst() {
-}


### PR DESCRIPTION
After a clean build gdk-pixbuf seemed to fail to compile, this commit fixes that problem