### PR TITLE
DO NOT remove libepoxy, only remove libfontconfig. Remove gdk-pixbuf

### DIFF
--- a/meta-hovergames-distro/recipes-hovergames/images/imx-image-hovergames-demo.bb
+++ b/meta-hovergames-distro/recipes-hovergames/images/imx-image-hovergames-demo.bb
@@ -542,13 +542,12 @@ fakeroot do_fix_ldconfig() {
 	echo >>"${APTGET_CHROOT_DIR}/etc/ld.so.conf.d/01-yocto.conf" "/usr/lib"
     rm ${IMAGE_ROOTFS}/usr/lib/libgudev*
     rm ${IMAGE_ROOTFS}/usr/lib/libgdk*
+    rm -rf ${IMAGE_ROOTFS}/usr/lib/gdk-pixbuf*
     rm ${IMAGE_ROOTFS}/usr/lib/libcairo*
-    rm ${IMAGE_ROOTFS}/usr/lib/libepoxy*
     rm ${IMAGE_ROOTFS}/usr/lib/libpango*
     rm ${IMAGE_ROOTFS}/usr/lib/libpixman*
     rm ${IMAGE_ROOTFS}/usr/lib/libpng*
-    rm ${IMAGE_ROOTFS}/usr/lib/libfreetype*
-    rm ${IMAGE_ROOTFS}/usr/lib/libfont*
+    rm ${IMAGE_ROOTFS}/usr/lib/libfontconfig*
     rm ${IMAGE_ROOTFS}/etc/fonts/fonts.conf
 
 	set +x


### PR DESCRIPTION
We shouldn't remove libepoxy gives some errors with X.
Remove Libfont changed to libfontconfig
Removed gdk-pixbuf folder which caused some warning in apt