### PR TITLE
linux-imx: Enable slcan module

### DIFF
--- a/meta-hovergames/recipes-kernel/linux/linux-imx/slcan.cfg
+++ b/meta-hovergames/recipes-kernel/linux/linux-imx/slcan.cfg
@@ -1,0 +1,2 @@
+# Config file to add SLCAN kernel module
+CONFIG_CAN_SLCAN=y

--- a/meta-hovergames/recipes-kernel/linux/linux-imx_5.4.bbappend
+++ b/meta-hovergames/recipes-kernel/linux/linux-imx_5.4.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += " \
     file://containers.cfg \
+	file://slcan.cfg \
     file://0001-Add-NavQ-device-trees.patch \
     file://0002-ARM64-dts-imx8mmnavq-Change-SD2_CD-pin-for-SDHC2.patch \
     file://0003-Add-OV5645-driver.patch \


### PR DESCRIPTION
Created new config file to enable slcan in the kernel.

Signed-off-by: Landon Haugh <landon.haugh@nxp.com>