### PR TITLE
recipes-licenses: change ownership of home folder back to navq:navq

### DIFF
--- a/meta-hovergames-distro/recipes-licenses/licenses/install-licenses_1.0.bb
+++ b/meta-hovergames-distro/recipes-licenses/licenses/install-licenses_1.0.bb
@@ -15,6 +15,7 @@ do_install() {
     install -m 0644 ${S}/EULA.txt ${D}/home/navq/
     install -m 0644 ${S}/HoverGamesLicense.txt ${D}/home/navq/
     install -m 0644 ${S}/SCR.txt ${D}/home/navq/
+    chown -R navq:navq ${D}/home/navq
 }
 
 FILES_${PN} = "/home/navq"

--- a/meta-hovergames-distro/recipes-licenses/licenses/install-licenses_1.0.bb
+++ b/meta-hovergames-distro/recipes-licenses/licenses/install-licenses_1.0.bb
@@ -10,6 +10,11 @@ SRC_URI = " \
 
 S = "${WORKDIR}"
 
+inherit useradd
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM_${PN} = "--system navq"
+USERADD_PARAM_${PN} = "--system -U navq"
+
 do_install() {
     install -d ${D}/home/navq
     install -m 0644 ${S}/EULA.txt ${D}/home/navq/


### PR DESCRIPTION
Current recipes-licenses will change ownership of the /home/navq folder to root:root. PR adds a line to the recipe to change ownership back to navq:navq so the user isn't confused when they can't write files to the home folder.